### PR TITLE
Add support for config path resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+* Added support for resolving schemas using a config base path
+
+## Changed
+* Refactored the schema assertions
 
 ## [0.2.0] - 2018-07-17
 ### Changed

--- a/README.md
+++ b/README.md
@@ -17,7 +17,53 @@ You can install the package via composer:
 > composer require sixlive/laravel-json-schema-assertions
 ```
 
+This package uses Laravel's [package discovery](https://laravel.com/docs/5.6/packages#package-discovery) to register the service provider to the framework. If you are using an older version of Laravel or do not use package discovery see below.
+
+<details>
+    <summary>Provider registration</summary>
+
+```php
+// config/app.php
+
+'providers' => [
+    sixlive\Laravel\JsonSchemaAssertions\ServiceProvider::class,
+]
+```
+
+</details>
+
+### Configuration
+Publish the packages config file:
+```bash
+> php artisan vendor:publish --provider="sixlive\Laravel\JsonSchemaAssertions\ServiceProvider" --tag="config"
+```
+
+This is the contents of the file which will be published at `config/json-schema-assertions`:
+```php
+return [
+    'schema_base_path' => base_path('schemas'),
+];
+```
+
 ## Usage
+
+If you are making use of external schema refrences e.g. `$ref: 'bar.json`, you mush reference the schema through file path or using the config path resolution.
+
+```
+├── app
+├── bootstrap
+├── config
+├── database
+├── public
+├── resources
+├── routes
+├── schemas
+│   ├── bar.json
+│   └── foo.json
+├── storage
+├── tests
+└── vendor
+```
 
 ```php
 /** @test */
@@ -40,8 +86,17 @@ public function it_has_a_valid_response()
     // Schema as an array
     $response->assertJsonSchema($schema);
 
+    // Schema from raw JSON
+    $response->assertJsonSchema(json_encode($schema));
+
     // Schema from a file
     $response->assertJsonSchema(base_path('schemas/foo.json'));
+
+    // Schema from config path
+    $response->assertJsonSchema('foo');
+
+    // Remote schema
+    $response->assertJsonSchema('https://docs.foo.io/schemas/foo.json');
 }
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
     "require": {
         "php": "^7.1|^7.2",
         "swaggest/json-schema": "^0.12.0",
-        "phpunit/phpunit": "^7.0"
+        "phpunit/phpunit": "^7.0",
+        "Illuminate/Support": "^5.5|^5.6"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.12",

--- a/config/config.php
+++ b/config/config.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'schema_base_path' => base_path('schemas'),
+];

--- a/src/SchemaAssertion.php
+++ b/src/SchemaAssertion.php
@@ -13,8 +13,6 @@ class SchemaAssertion
 
     /**
      * @param  array|string  $schema
-     *
-     * @return void
      */
     public function __construct($schema)
     {
@@ -22,8 +20,12 @@ class SchemaAssertion
             $schema = json_encode($schema);
         }
 
-        if (is_string($schema) && Str::isJson($schema)) {
+        if ($this->isJson($schema)) {
             $schema = json_decode($schema);
+        }
+
+        if ($this->isFileFromConfigPath($schema)) {
+            $schema = $this->mergeConfigPath($schema);
         }
 
         $this->schema = Schema::import($schema);
@@ -45,5 +47,45 @@ class SchemaAssertion
         }
 
         PHPUnit::assertTrue(true);
+    }
+
+    /**
+     * Test if the schema is a JSON string.
+     *
+     * @param  mixed  $schema
+     *
+     * @return bool
+     */
+    private function isJson($schema)
+    {
+        return is_string($schema) && Str::isJson($schema);
+    }
+
+    /**
+     * Test if the schema is being loaded from the config path.
+     *
+     * @param  mixed  $schema
+     *
+     * @return bool
+     */
+    private function isFileFromConfigPath($schema)
+    {
+        return is_string($schema)
+            && file_exists($this->mergeConfigPath($schema));
+    }
+
+    /**
+     * Merge the provided path with the config path and file extension.
+     *
+     * @param  string  $schema
+     *
+     * @return string
+     */
+    private function mergeConfigPath($schema)
+    {
+        return vsprintf('%s/%s.json', [
+            config('json-schema-assertions.schema_base_path'),
+            $schema,
+        ]);
     }
 }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -12,8 +12,22 @@ class ServiceProvider extends Provider
      */
     public function boot()
     {
+        if ($this->app->runningInConsole()) {
+            $this->publishes([
+                __DIR__.'/../config/config.php' => config_path('json-schema-assertions.php'),
+            ], 'config');
+        }
+
         TestResponse::macro('assertJsonSchema', function ($schema) {
             (new SchemaAssertion($schema))->assert($this->content());
         });
+    }
+
+    /**
+     * Register the application services.
+     */
+    public function register()
+    {
+        $this->mergeConfigFrom(__DIR__.'/../config/config.php', 'json-schema-assertions');
     }
 }

--- a/tests/AssertResponseTest.php
+++ b/tests/AssertResponseTest.php
@@ -80,4 +80,10 @@ class AssertResponseTest extends TestCase
 
         $this->get('foo')->assertJsonSchema(json_encode($schema));
     }
+
+    /** @test */
+    public function valid_schema_passes_as_config_path()
+    {
+        $this->get('foo')->assertJsonSchema('foo');
+    }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -10,4 +10,12 @@ class TestCase extends \Orchestra\Testbench\TestCase
     {
         return [ServiceProvider::class];
     }
+
+    protected function getEnvironmentSetUp($app)
+    {
+        $app['config']->set(
+            'json-schema-assertions.schema_base_path',
+            __DIR__.'/Support/Schemas'
+        );
+    }
 }


### PR DESCRIPTION
## Status
**READY**

## Description
Adds support for config path resolution


## Todos
- [x] Tests
- [x] Documentation
- [x] Changelog Entry (unreleased)

## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.

```bash
> git pull --prune
> git checkout add-support-for-config-path-resolution
> vendor/bin/phpunit
```
