### PR TITLE
Make assertions chainable 

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -20,6 +20,7 @@ class ServiceProvider extends Provider
 
         TestResponse::macro('assertJsonSchema', function ($schema) {
             (new SchemaAssertion($schema))->assert($this->content());
+            return $this;
         });
     }
 


### PR DESCRIPTION
Returning $this from the assertion to allow chaining of assertions.

## Status
**READY**

## Description
By returning $this in the assertion, further chaining can happen after the assertion.